### PR TITLE
[GitHub Action] Added job that uploads `*.deb` and `*.rpm` on releases

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
           sudo apt-get install -y ruby ruby-dev rubygems build-essential python3-simplejson python3-pkg-resources python3-setuptools
           sudo gem install fpm
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build package
         run: >
           fpm --input-type  python                                 \
@@ -31,7 +31,7 @@ jobs:
               --depends systemd                                    \
               setup.py
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DEB package (Ubuntu 20.04)
           path: |
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get install -y ruby ruby-dev rubygems build-essential python3-simplejson python3-pkg-resources python3-setuptools
           sudo gem install fpm
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build package
         run: >
           fpm --input-type  python                                 \
@@ -64,7 +64,7 @@ jobs:
               --depends systemd                                    \
               setup.py
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DEB package (Ubuntu 22.04)
           path: |
@@ -80,7 +80,7 @@ jobs:
           sudo apt-get install -y ruby ruby-dev rubygems build-essential python3-simplejson python3-pkg-resources python3-setuptools
           sudo gem install fpm
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build package
         run: >
           fpm --input-type  python                                 \
@@ -97,7 +97,7 @@ jobs:
               --depends systemd                                    \
               setup.py
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DEB package (Ubuntu 24.04)
           path: |
@@ -112,7 +112,7 @@ jobs:
       - name: Install tito
         run: dnf install -y tito python3-devel
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: List contents
@@ -120,7 +120,7 @@ jobs:
       - name: Build package
         run: tito build --rpm --offline --test
       - name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: RPM package
           path: |
@@ -128,10 +128,10 @@ jobs:
 
   tests:
     name: Run tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt-get update
@@ -146,7 +146,7 @@ jobs:
       - build-deb-20-04
     steps:
       - name: Download DEB package
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: DEB package (Ubuntu 20.04)
           path: /tmp
@@ -168,7 +168,7 @@ jobs:
       - build-deb-22-04
     steps:
       - name: Download DEB package
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: DEB package (Ubuntu 22.04)
           path: /tmp
@@ -190,7 +190,7 @@ jobs:
       - build-deb-24-04
     steps:
       - name: Download DEB package
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: DEB package (Ubuntu 24.04)
           path: /tmp
@@ -217,7 +217,7 @@ jobs:
       - test-deb-24-04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: all-artifacts
       - name: Rename Ubuntu deb packages
@@ -236,7 +236,7 @@ jobs:
           mv "${FILENAME_20_04}" "${FILENAME_20_04/_all/_20.04_all}"
           cd - || exit 1
       - name: Upload artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             all-artifacts/*/*.deb

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,6 +70,39 @@ jobs:
           path: |
             *.deb
 
+  build-deb-24-04:
+    name: Build DEB package (Ubuntu 24.04)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install fpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby ruby-dev rubygems build-essential python3-simplejson python3-pkg-resources python3-setuptools
+          sudo gem install fpm
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Build package
+        run: >
+          fpm --input-type  python                                 \
+              --output-type deb                                    \
+              --python-bin=python3                                 \
+              --python-install-bin /usr/bin                        \
+              --deb-systemd debian/systemd-resolved-docker.service \
+              --no-auto-depends                                    \
+              --depends python3-docker                             \
+              --depends python3-dnslib                             \
+              --depends python3-dbus                               \
+              --depends python3-pyroute2                           \
+              --depends python3-systemd                            \
+              --depends systemd                                    \
+              setup.py
+      - name: Save artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: DEB package (Ubuntu 24.04)
+          path: |
+            *.deb
+
   build-rpm:
     name: Build RPM package
     runs-on: ubuntu-22.04
@@ -150,6 +183,28 @@ jobs:
       - name: Test Query
         run: resolvectl query test-container.docker
 
+  test-deb-24-04:
+    name: Test DEB package (Ubuntu 24.04)
+    runs-on: ubuntu-24.04
+    needs:
+      - build-deb-24-04
+    steps:
+      - name: Download DEB package
+        uses: actions/download-artifact@master
+        with:
+          name: DEB package (Ubuntu 24.04)
+          path: /tmp
+      - name: Install package
+        run: sudo apt install /tmp/python-systemd-resolved-docker_*.deb
+      - name: Start service
+        run: sudo systemctl start systemd-resolved-docker
+      - name: Start continaer
+        run: docker run --detach --interactive --hostname test-container alpine
+      - name: resolvectl status
+        run: resolvectl status
+      - name: Test Query
+        run: resolvectl query test-container.docker
+
   upload-artifacts-to-release:
     name: Upload artifacts to release
     if: startsWith(github.ref, 'refs/tags/')
@@ -159,6 +214,7 @@ jobs:
       - tests
       - test-deb-20-04
       - test-deb-22-04
+      - test-deb-24-04
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -167,6 +223,10 @@ jobs:
       - name: Rename Ubuntu deb packages
         shell: bash
         run: |
+          cd "all-artifacts/DEB package (Ubuntu 24.04)" || exit 1
+          FILENAME_24_04="$(ls python-systemd-resolved-docker_*_all.deb)"
+          mv "${FILENAME_24_04}" "${FILENAME_24_04/_all/_24.04_all}"
+          cd - || exit 1
           cd "all-artifacts/DEB package (Ubuntu 22.04)" || exit 1
           FILENAME_22_04="$(ls python-systemd-resolved-docker_*_all.deb)"
           mv "${FILENAME_22_04}" "${FILENAME_22_04/_all/_22.04_all}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,7 @@
 name: Build Packages
 on: [ push ]
+permissions:
+  contents: write
 jobs:
   build-deb-20-04:
     name: Build DEB package (Ubuntu 20.04)
@@ -147,3 +149,35 @@ jobs:
         run: resolvectl status
       - name: Test Query
         run: resolvectl query test-container.docker
+
+  upload-artifacts-to-release:
+    name: Upload artifacts to release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - build-rpm
+      - tests
+      - test-deb-20-04
+      - test-deb-22-04
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: all-artifacts
+      - name: Rename Ubuntu deb packages
+        shell: bash
+        run: |
+          cd "all-artifacts/DEB package (Ubuntu 22.04)" || exit 1
+          FILENAME_22_04="$(ls python-systemd-resolved-docker_*_all.deb)"
+          mv "${FILENAME_22_04}" "${FILENAME_22_04/_all/_22.04_all}"
+          cd - || exit 1
+          cd "all-artifacts/DEB package (Ubuntu 20.04)" || exit 1
+          FILENAME_20_04="$(ls python-systemd-resolved-docker_*_all.deb)"
+          mv "${FILENAME_20_04}" "${FILENAME_20_04/_all/_20.04_all}"
+          cd - || exit 1
+      - name: Upload artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            all-artifacts/*/*.deb
+            all-artifacts/*/*.rpm

--- a/test/integration/test_compose.sh
+++ b/test/integration/test_compose.sh
@@ -46,13 +46,24 @@ networks:
       driver: default
 EOF
 
+echo 'Before ALLOWED_DOMAINS'
+
 ALLOWED_DOMAINS=.docker,.$TEST_PREFIX start_systemd_resolved_docker
+
+echo 'After ALLOWED_DOMAINS'
+echo 'Before first docker compose'
 
 docker compose --file /dev/fd/10 --project-name $TEST_PREFIX up --detach --scale webserver=2
 
+echo 'After first docker compose'
+echo "Before docker_ip ${TEST_PREFIX}-broker-1"
+
 broker1_ip=$(docker_ip ${TEST_PREFIX}-broker-1)
+echo "broker1_ip is ${broker1_ip}"
 webserver1_ip=$(docker_ip ${TEST_PREFIX}-webserver-1)
+echo "webserver1_ip is ${webserver1_ip}"
 webserver2_ip=$(docker_ip ${TEST_PREFIX}-webserver-2)
+echo "webserver2_ip is ${webserver2_ip}"
 
 query_ok     broker.$TEST_PREFIX $broker1_ip
 query_ok   1.broker.$TEST_PREFIX $broker1_ip
@@ -64,5 +75,10 @@ query_ok   2.webserver.$TEST_PREFIX $webserver2_ip
 
 query_ok     broker.docker $broker1_ip
 
+echo 'Before second docker compose'
+
 docker compose --file /dev/fd/20 --project-name ${TEST_PREFIX}_2 up --detach
+
+echo 'After second docker compose'
+
 query_fail   broker.docker

--- a/test/integration/test_compose.sh
+++ b/test/integration/test_compose.sh
@@ -50,7 +50,7 @@ EOF
 
 ALLOWED_DOMAINS=.docker,.$TEST_PREFIX start_systemd_resolved_docker
 
-docker-compose --file /dev/fd/10 --project-name $TEST_PREFIX up --detach --scale webserver=2
+docker compose --file /dev/fd/10 --project-name $TEST_PREFIX up --detach --scale webserver=2
 
 broker1_ip=$(docker_ip ${TEST_PREFIX}_broker_1)
 webserver1_ip=$(docker_ip ${TEST_PREFIX}_webserver_1)
@@ -66,5 +66,5 @@ query_ok   2.webserver.$TEST_PREFIX $webserver2_ip
 
 query_ok     broker.docker $broker1_ip
 
-docker-compose --file /dev/fd/20 --project-name ${TEST_PREFIX}_2 up --detach
+docker compose --file /dev/fd/20 --project-name ${TEST_PREFIX}_2 up --detach
 query_fail   broker.docker

--- a/test/integration/test_compose.sh
+++ b/test/integration/test_compose.sh
@@ -3,7 +3,6 @@
 . ./functions.sh
 
 exec 10<<EOF
-version: "2.1"
 services:
   webserver:
     image: nginx
@@ -29,7 +28,6 @@ networks:
 EOF
 
 exec 20<<EOF
-version: "2.1"
 services:
   broker:
     image: redis

--- a/test/integration/test_compose.sh
+++ b/test/integration/test_compose.sh
@@ -50,9 +50,9 @@ ALLOWED_DOMAINS=.docker,.$TEST_PREFIX start_systemd_resolved_docker
 
 docker compose --file /dev/fd/10 --project-name $TEST_PREFIX up --detach --scale webserver=2
 
-broker1_ip=$(docker_ip ${TEST_PREFIX}_broker_1)
-webserver1_ip=$(docker_ip ${TEST_PREFIX}_webserver_1)
-webserver2_ip=$(docker_ip ${TEST_PREFIX}_webserver_2)
+broker1_ip=$(docker_ip ${TEST_PREFIX}-broker-1)
+webserver1_ip=$(docker_ip ${TEST_PREFIX}-webserver-1)
+webserver2_ip=$(docker_ip ${TEST_PREFIX}-webserver-2)
 
 query_ok     broker.$TEST_PREFIX $broker1_ip
 query_ok   1.broker.$TEST_PREFIX $broker1_ip


### PR DESCRIPTION
This change would push `*.deb` and `*.rpm` to a release

Example: https://github.com/missingcharacter/systemd-resolved-docker/releases/tag/v1.0.1-rc1

![image](https://user-images.githubusercontent.com/728243/233540567-880c110e-b8c9-4871-a018-54520b4be8ac.png)


You can see a job run here: https://github.com/missingcharacter/systemd-resolved-docker/actions/runs/4761276644/jobs/8462391797

![image](https://user-images.githubusercontent.com/728243/233540817-fdf6ad54-c411-41a8-b10e-fdb7259cff3b.png)
